### PR TITLE
What: `git submodule update` timeout extended.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 rootProject.name = 'protop-gradle-plugin'
 
 if (!new File('protop/build.gradle').exists()) {
-  ['git', 'submodule', 'update', '--init'].execute().waitForOrKill(1000)
+  ['git', 'submodule', 'update', '--init'].execute().waitForOrKill(12000)
 }
 
 includeBuild 'protop'


### PR DESCRIPTION
Why: To fix CI build.